### PR TITLE
로그인 관련 상태 관리, 구독 캘린더 API 요청, 여러가지 UI 수정 

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,9 +1,20 @@
 import axios from "axios";
 
-export async function requestSocialLogin(provider, accessToken) {
+// 소셜 로그인 요청
+export async function requestSocialLogin(platform, code) {
   const response = await axios.post("/api/auth/social-login", {
-    provider: provider,
-    access_token: accessToken,
+    provider: platform,
+    access_token: code,
+  });
+  return response.data;
+}
+
+// 사용자 정보 조회
+export async function fetchUserInfo(token) {
+  const response = await axios.get(`/api/users/me`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   });
   return response.data;
 }

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-// 소셜 로그인 요청
+// 소셜 로그인
 export async function requestSocialLogin(platform, code) {
   const response = await axios.post("/api/auth/social-login", {
     provider: platform,

--- a/src/components/CalendarInfoModal.jsx
+++ b/src/components/CalendarInfoModal.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { FaTrashCan, FaXmark } from "react-icons/fa6";
+import { useAuth } from "../context/AuthContext";
 
 import {
   FaCheck,
@@ -22,6 +23,7 @@ export default function CalendarInfo({ calendar, onClose, userId }) {
     visitCode: calendar.invitation_code,
   });
 
+  const { loggedIn, userInfo, setLoggedIn } = useAuth();
   const [isEdit, setIsEdit] = useState(false);
 
   // 상태 변경 핸들러
@@ -47,7 +49,7 @@ export default function CalendarInfo({ calendar, onClose, userId }) {
   // 컴포넌트가 마운트될 때 creator_id와 userId 확인
   useEffect(() => {
     console.log("Calendar Creator ID:", calendar.creator_id);
-    console.log("Current User ID:", userId);
+    console.log("Current User ID:", userInfo.user_id);
   }, [calendar.creator_id, userId]);
 
   // 저장
@@ -263,7 +265,7 @@ export default function CalendarInfo({ calendar, onClose, userId }) {
             className="cursor-pointer text-[1.5rem] text-darkGray"
             onClick={() => setIsEdit(true)}
           />
-          {calendar.creator_id === userId && (
+          {calendar.creator_id === userInfo.user_id && (
             <FaTrashCan
               className="cursor-pointer text-[1.5rem] text-darkGray"
               onClick={handleDelete}

--- a/src/components/CreateEventModal.jsx
+++ b/src/components/CreateEventModal.jsx
@@ -1,9 +1,9 @@
 import "react-datepicker/dist/react-datepicker.css";
 import DatePicker from "react-datepicker";
 import React, { useEffect, useState } from "react";
+import axios from "axios";
 import { FaCaretDown, FaToggleOff, FaToggleOn } from "react-icons/fa";
 import { FaXmark } from "react-icons/fa6";
-import axios from "axios";
 
 export default function CreateEvent({ onClose, setEvents }) {
   //캘린더 더미데이터

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -57,11 +57,11 @@ export default function Header() {
             icon={faUser}
             className="mb-[1rem] mt-[0.5rem] text-[1.5rem] text-eventoPurpleDark"
           />
-          <p className="mb-[1.4rem] text-center text-[1.25rem] font-medium">
+          <p className="mb-[1.4rem] text-center text-[1.25rem] font-medium text-eventoblack">
             {userInfo?.user_name || "Guest"}
           </p>
           <button
-            className="mb-[0.3rem] h-[2rem] w-[7rem] cursor-pointer rounded-[0.5rem] text-[0.95rem] font-semibold hover:bg-eventoPurpleLight hover:text-eventoPurple"
+            className="mb-[0.3rem] h-[2rem] w-[7rem] cursor-pointer rounded-[0.5rem] text-[0.95rem] font-semibold text-darkGray hover:bg-eventoPurpleLight hover:text-eventoPurple"
             onClick={() => {
               setView();
               navigate("/profile");
@@ -70,7 +70,7 @@ export default function Header() {
             내 프로필
           </button>
           <button
-            className="h-[2rem] w-[7rem] cursor-pointer rounded-[0.5rem] text-[0.95rem] font-semibold hover:bg-lightRed hover:text-darkRed"
+            className="h-[2rem] w-[7rem] cursor-pointer rounded-[0.5rem] text-[0.95rem] font-semibold text-darkGray hover:bg-lightRed hover:text-darkRed"
             onClick={handleLogout}
           >
             로그아웃

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,7 +6,7 @@ import { useAuth } from "../context/AuthContext";
 
 export default function Header() {
   const navigate = useNavigate();
-  const { isLoggedIn, setLoggedIn, userInfo } = useAuth();
+  const { loggedIn, setLoggedIn, userInfo } = useAuth(); // loggedIn으로 수정
   const [isView, setIsView] = useState(false);
 
   const setView = () => {
@@ -20,6 +20,7 @@ export default function Header() {
   };
 
   useEffect(() => {
+    // localStorage에서 토큰 확인
     const token = localStorage.getItem("token");
     if (token) {
       setLoggedIn(true);
@@ -36,7 +37,7 @@ export default function Header() {
         alt="Evento"
         onClick={() => navigate("/calendar")}
       />
-      {!isLoggedIn ? (
+      {!loggedIn ? (
         <button
           className="h-[2.5rem] w-[5rem] rounded-[0.5rem] bg-eventoPurple text-[0.95rem] font-semibold text-white hover:bg-eventoPurple/80 active:bg-eventoPurpleLight active:text-eventoPurple/80"
           onClick={() => navigate("/login")}
@@ -46,21 +47,21 @@ export default function Header() {
       ) : (
         <FontAwesomeIcon
           icon={faUser}
-          className="text-2xl text-[#4F378B]"
+          className="cursor-pointer text-2xl text-eventoPurpleDark"
           onClick={setView}
         />
       )}
-      {isView && isLoggedIn && (
+      {isView && loggedIn && (
         <div className="bg-event absolute right-[1rem] top-[4rem] z-10 flex h-[13em] w-[10rem] flex-col items-center justify-center rounded-[1rem] border-solid border-eventoPurpleLight bg-zinc-100 text-eventoblack">
           <FontAwesomeIcon
             icon={faUser}
-            className="mb-[1rem] mt-[0.5rem] text-[1.5rem] text-[#4F378B]"
+            className="mb-[1rem] mt-[0.5rem] text-[1.5rem] text-eventoPurpleDark"
           />
           <p className="mb-[1.4rem] text-center text-[1.25rem] font-medium">
-            {userInfo?.user_name || "Evento1"}
+            {userInfo?.user_name || "Guest"}
           </p>
           <button
-            className="mb-[0.3rem] h-[2rem] w-[7rem] rounded-[0.5rem] text-[0.95rem] font-semibold hover:bg-eventoPurpleLight hover:text-eventoPurple"
+            className="mb-[0.3rem] h-[2rem] w-[7rem] cursor-pointer rounded-[0.5rem] text-[0.95rem] font-semibold hover:bg-eventoPurpleLight hover:text-eventoPurple"
             onClick={() => {
               setView();
               navigate("/profile");
@@ -69,7 +70,7 @@ export default function Header() {
             내 프로필
           </button>
           <button
-            className="h-[2rem] w-[7rem] rounded-[0.5rem] text-[0.95rem] font-semibold hover:bg-lightRed hover:text-darkRed"
+            className="h-[2rem] w-[7rem] cursor-pointer rounded-[0.5rem] text-[0.95rem] font-semibold hover:bg-lightRed hover:text-darkRed"
             onClick={handleLogout}
           >
             로그아웃

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,7 +6,7 @@ import { useAuth } from "../context/AuthContext";
 
 export default function Header() {
   const navigate = useNavigate();
-  const { loggedIn, setLoggedIn, userInfo } = useAuth(); // loggedIn으로 수정
+  const { loggedIn, setLoggedIn, userInfo } = useAuth();
   const [isView, setIsView] = useState(false);
 
   const setView = () => {
@@ -26,8 +26,10 @@ export default function Header() {
       setLoggedIn(true);
     } else {
       setLoggedIn(false);
+      navigate("/login");
     }
-  }, [setLoggedIn]);
+    console.log(`User logged in: ${loggedIn}`);
+  }, []);
 
   return (
     <div className="evento-header absolute flex h-[5rem] w-full cursor-pointer items-center justify-between py-[1.25rem] pl-[2rem] pr-[2rem]">

--- a/src/components/SideBarLeft.jsx
+++ b/src/components/SideBarLeft.jsx
@@ -4,6 +4,7 @@ import InviteCodeModal from "./InviteCodeModal";
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 import {
   FaRegSquare,
@@ -17,11 +18,12 @@ export default function SideBarLeft() {
   const [isCalendarInfoOpen, setCalendarInfoOpen] = useState(false);
   const [selectedCalendar, setSelectedCalendar] = useState(null);
   const [myCalendars, setMyCalendars] = useState([]);
-  const [myUserId, setMyUserId] = useState(null); // 사용자 ID를 저장할 상태 추가
   const navigate = useNavigate();
   const [checked, setChecked] = useState({});
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [isCreateCalendarOpen, setIsCreateCalendarOpen] = useState(false);
+
+  const { loggedIn, userInfo, setLoggedIn } = useAuth();
 
   // 내 캘린더 데이터 가져오기
   useEffect(() => {
@@ -42,26 +44,26 @@ export default function SideBarLeft() {
       }
     }
 
-    async function fetchUser() {
-      try {
-        const token = localStorage.getItem("token"); // 토큰 가져오기
-        const response = await axios.get("/api/users/me", {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
+    // async function fetchUser() {
+    //   try {
+    //     const token = localStorage.getItem("token"); // 토큰 가져오기
+    //     const response = await axios.get("/api/users/me", {
+    //       headers: {
+    //         Authorization: `Bearer ${token}`,
+    //       },
+    //     });
 
-        if (response.status === 200) {
-          setMyUserId(response.data.user_id); // 사용자 ID 설정
-        }
-      } catch (error) {
-        console.error("사용자 정보를 가져오는 중 오류 발생:", error);
-      }
-    }
+    //     if (response.status === 200) {
+    //       setMyUserId(response.data.user_id); // 사용자 ID 설정
+    //     }
+    //   } catch (error) {
+    //     console.error("사용자 정보를 가져오는 중 오류 발생:", error);
+    //   }
+    // }
 
     // 사용자 정보와 캘린더 정보 모두 가져오기
     fetchCalendars();
-    fetchUser();
+    // fetchUser();
   }, [isCalendarInfoOpen, isCreateCalendarOpen]);
 
   const handleToggle = (id) => {
@@ -93,7 +95,6 @@ export default function SideBarLeft() {
           : calendar,
       ),
     );
-    // 모달을 닫음
     setCalendarInfoOpen(false);
   };
 
@@ -228,7 +229,7 @@ export default function SideBarLeft() {
             calendar={selectedCalendar}
             onClose={() => setCalendarInfoOpen(false)}
             onSave={handleSaveCalendar}
-            userId={myUserId} // 현재 로그인한 사용자 ID 전달
+            userId={userInfo.user_id} // 현재 로그인한 사용자 ID 전달
           />
         </div>
       )}

--- a/src/components/SideBarLeft.jsx
+++ b/src/components/SideBarLeft.jsx
@@ -18,14 +18,42 @@ export default function SideBarLeft() {
   const [isCalendarInfoOpen, setCalendarInfoOpen] = useState(false);
   const [selectedCalendar, setSelectedCalendar] = useState(null);
   const [myCalendars, setMyCalendars] = useState([]);
+  const [subscribedCalendars, setSubscribedCalendars] = useState([]);
   const navigate = useNavigate();
   const [checked, setChecked] = useState({});
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [isCreateCalendarOpen, setIsCreateCalendarOpen] = useState(false);
 
-  const { loggedIn, userInfo, setLoggedIn } = useAuth();
-
   // 내 캘린더 데이터 가져오기
+
+  // 구독 캘린더 데이터 가져오기
+  const { loggedIn, userInfo } = useAuth();
+
+  useEffect(() => {
+    async function fetchSubscribedCalendars() {
+      try {
+        const token = localStorage.getItem("token");
+        const response = await axios.get(
+          `/api/users/${userInfo.user_id}/subscriptions`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        );
+
+        if (response.status === 200) {
+          setSubscribedCalendars(response.data);
+        }
+      } catch (error) {
+        console.error("구독 캘린더 정보를 가져오는 중 오류 발생:", error);
+      }
+    }
+
+    fetchSubscribedCalendars();
+  }, [userInfo]);
+
+  // 내 캘린더 데이터 가져오기 함수
   useEffect(() => {
     async function fetchCalendars() {
       try {
@@ -40,13 +68,14 @@ export default function SideBarLeft() {
           setMyCalendars(response.data);
         }
       } catch (error) {
-        console.error("캘린더 정보를 가져오는 중 오류 발생:", error);
+        console.error("내 캘린더 정보를 가져오는 중 오류 발생:", error);
       }
     }
 
     fetchCalendars();
-    // fetchUser();
   }, [isCalendarInfoOpen, isCreateCalendarOpen]);
+
+  // 구독한 캘린더 데이터 가져오기
 
   const handleToggle = (id) => {
     setChecked((prev) => ({
@@ -58,6 +87,7 @@ export default function SideBarLeft() {
   const toggleInvite = () => {
     setIsInviteOpen((prev) => !prev);
   };
+
   const toggleCreateCalendar = () => {
     setIsCreateCalendarOpen((prev) => !prev);
   };
@@ -151,47 +181,32 @@ export default function SideBarLeft() {
             <ul className="m-[1rem] mt-[1.5rem] space-y-[0.5rem]">
               {subscribedCalendars.map((calendar) => (
                 <li
-                  key={calendar.id}
+                  key={calendar.calendar_id}
                   className="flex items-center space-x-[0.5rem]"
                 >
                   <div
                     className="cursor-pointer"
-                    onClick={() => handleToggle(calendar.id)}
+                    onClick={() => handleToggle(calendar.calendar_id)}
                   >
-                    {checked[calendar.id] ? (
+                    {checked[calendar.calendar_id] ? (
                       <FaCheckSquare className="text-[0.9rem] text-eventoPurpleBase" />
                     ) : (
                       <FaRegSquare className="text-[0.9rem] text-eventoPurpleBase" />
                     )}
                   </div>
                   <label
-                    htmlFor={calendar.id}
+                    htmlFor={calendar.calendar_id}
                     className="flex items-center text-[0.9rem] font-medium text-eventoPurpleBase"
                   >
-                    {calendar.label}
+                    {calendar.calendar_name}
                     <span className="ml-2 text-[0.7rem] font-light text-darkGray">
-                      {calendar.description}
+                      {calendar.calendar_description}
                     </span>
                   </label>
                 </li>
               ))}
             </ul>
           </div>
-        </div>
-        {/* 디데이 */}
-        <div className="fixed bottom-[4rem] left-[4rem] flex flex-col items-center justify-center">
-          <ul className="space-y-[1.2rem]">
-            {dDayItems.map((item, index) => (
-              <li key={index} className="flex">
-                <span className="w-[3rem] text-left font-bold text-eventoPurpleBase">
-                  {item.day}
-                </span>
-                <span className="flex-1 pl-2 text-left text-[0.93rem] text-[#646464]">
-                  {item.description}
-                </span>
-              </li>
-            ))}
-          </ul>
         </div>
       </div>
       {/* 모달들 */}
@@ -211,22 +226,13 @@ export default function SideBarLeft() {
             calendar={selectedCalendar}
             onClose={() => setCalendarInfoOpen(false)}
             onSave={handleSaveCalendar}
-            userId={userInfo.user_id} // 현재 로그인한 사용자 ID 전달
+            userId={userInfo?.user_id} // 현재 로그인한 사용자 ID 전달
           />
         </div>
       )}
     </div>
   );
 }
-
-// 기존 더미 데이터 사용 - 구독한 캘린더
-const subscribedCalendars = [
-  { id: "5", label: "therock", description: "Dwayne Johnson" },
-  { id: "6", label: "bts.bighitofficial", description: "BTS" },
-  { id: "7", label: "dlwlrma", description: "IU" },
-  { id: "8", label: "xxxibgdrgn", description: "G-DRAGON" },
-  { id: "9", label: "songkang_b", description: "송강" },
-];
 
 const dDayItems = [
   { day: "D-1", description: "evento 배포" },

--- a/src/components/SideBarLeft.jsx
+++ b/src/components/SideBarLeft.jsx
@@ -44,24 +44,6 @@ export default function SideBarLeft() {
       }
     }
 
-    // async function fetchUser() {
-    //   try {
-    //     const token = localStorage.getItem("token"); // 토큰 가져오기
-    //     const response = await axios.get("/api/users/me", {
-    //       headers: {
-    //         Authorization: `Bearer ${token}`,
-    //       },
-    //     });
-
-    //     if (response.status === 200) {
-    //       setMyUserId(response.data.user_id); // 사용자 ID 설정
-    //     }
-    //   } catch (error) {
-    //     console.error("사용자 정보를 가져오는 중 오류 발생:", error);
-    //   }
-    // }
-
-    // 사용자 정보와 캘린더 정보 모두 가져오기
     fetchCalendars();
     // fetchUser();
   }, [isCalendarInfoOpen, isCreateCalendarOpen]);

--- a/src/components/SideBarLeft.jsx
+++ b/src/components/SideBarLeft.jsx
@@ -20,62 +20,42 @@ export default function SideBarLeft() {
   const [myCalendars, setMyCalendars] = useState([]);
   const [subscribedCalendars, setSubscribedCalendars] = useState([]);
   const navigate = useNavigate();
+
   const [checked, setChecked] = useState({});
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [isCreateCalendarOpen, setIsCreateCalendarOpen] = useState(false);
 
-  // 내 캘린더 데이터 가져오기
-
-  // 구독 캘린더 데이터 가져오기
   const { loggedIn, userInfo } = useAuth();
 
   useEffect(() => {
-    async function fetchSubscribedCalendars() {
+    async function fetchData() {
       try {
         const token = localStorage.getItem("token");
-        const response = await axios.get(
-          `/api/users/${userInfo.user_id}/subscriptions`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          },
-        );
+        const [myCalendarsResponse, subscribedCalendarsResponse] =
+          await Promise.all([
+            axios.get("/api/calendars/admins", {
+              headers: { Authorization: `Bearer ${token}` },
+            }),
+            axios.get(`/api/users/${userInfo.user_id}/subscriptions`, {
+              headers: { Authorization: `Bearer ${token}` },
+            }),
+          ]);
 
-        if (response.status === 200) {
-          setSubscribedCalendars(response.data);
+        if (myCalendarsResponse.status === 200) {
+          setMyCalendars(myCalendarsResponse.data);
+        }
+        if (subscribedCalendarsResponse.status === 200) {
+          setSubscribedCalendars(subscribedCalendarsResponse.data);
         }
       } catch (error) {
-        console.error("구독 캘린더 정보를 가져오는 중 오류 발생:", error);
+        console.error("캘린더 데이터를 가져오는 중 오류 발생:", error);
       }
     }
 
-    fetchSubscribedCalendars();
-  }, [userInfo]);
-
-  // 내 캘린더 데이터 가져오기 함수
-  useEffect(() => {
-    async function fetchCalendars() {
-      try {
-        const token = localStorage.getItem("token"); // 토큰 가져오기
-        const response = await axios.get("/api/calendars/admins", {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-
-        if (response.status === 200) {
-          setMyCalendars(response.data);
-        }
-      } catch (error) {
-        console.error("내 캘린더 정보를 가져오는 중 오류 발생:", error);
-      }
+    if (userInfo?.user_id) {
+      fetchData();
     }
-
-    fetchCalendars();
-  }, [isCalendarInfoOpen, isCreateCalendarOpen]);
-
-  // 구독한 캘린더 데이터 가져오기
+  }, [userInfo, isCalendarInfoOpen, isCreateCalendarOpen]);
 
   const handleToggle = (id) => {
     setChecked((prev) => ({

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,25 +1,24 @@
 import React, { createContext, useContext, useState } from "react";
 
+// AuthContext 생성
 const AuthContext = createContext();
 
+// Context Provider Component 생성
 export function AuthProvider({ children }) {
   const [loggedIn, setLoggedIn] = useState(false);
-  const [userInfo, setUserInfo] = useState(null); // 사용자 정보 전역 관리
+  const [userInfo, setUserInfo] = useState(null);
+  // const [loading, setLoading] = useState(true); // 로딩 상태 추가
 
   return (
     <AuthContext.Provider
-      value={{
-        loggedIn,
-        setLoggedIn,
-        userInfo,
-        setUserInfo,
-      }}
+      value={{ loggedIn, setLoggedIn, userInfo, setUserInfo }}
     >
       {children}
     </AuthContext.Provider>
   );
 }
 
+// Context 커스텀 훅 생성
 export function useAuth() {
   return useContext(AuthContext);
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,23 +1,25 @@
 import React, { createContext, useContext, useState } from "react";
 
-// AuthContext 생성
 const AuthContext = createContext();
 
-// Context Provider Component 생성
 export function AuthProvider({ children }) {
-  const [isLoggedIn, setLoggedIn] = useState(false);
-  const [userInfo, setUserInfo] = useState(null);
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [userInfo, setUserInfo] = useState(null); // 사용자 정보 전역 관리
 
   return (
     <AuthContext.Provider
-      value={{ isLoggedIn, setLoggedIn, userInfo, setUserInfo }}
+      value={{
+        loggedIn,
+        setLoggedIn,
+        userInfo,
+        setUserInfo,
+      }}
     >
       {children}
     </AuthContext.Provider>
   );
 }
 
-// Context 커스텀 훅 생성
 export function useAuth() {
   return useContext(AuthContext);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -151,3 +151,39 @@ body {
   min-height: 100vh;
   font-family: "Pretendard", sans-serif;
 }
+
+.react-datepicker {
+  background-color: #f9f5ff !important;
+  border: none !important;
+  outline: none !important;
+  text-align: right !important;
+}
+
+.react-datepicker__header {
+  background-color: #EADDFF !important;
+  color: #4F378B !important;
+  border-bottom: none !important;
+}
+
+.react-datepicker__day--selected {
+  background-color: #8867DF !important;
+  color: white !important;
+}
+
+.react-datepicker__day--today {
+  border: 1px solid #6d87d5 !important;
+}
+
+.react-datepicker__input-container input {
+  outline: none !important;
+  border: none !important;
+  text-align: right !important;
+}
+
+.react-datepicker__day {
+  outline: none !important;
+}
+
+.react-datepicker__day:hover {
+  background-color: #EADDFF !important;
+}

--- a/src/mocks/handlers/calendarHandlers.js
+++ b/src/mocks/handlers/calendarHandlers.js
@@ -23,7 +23,7 @@ let mockCalendars = [
     creator_id: 2,
     invitation_code: "G3G7H3",
     members: [
-      { id: 11, nickname: "Manager1" },
+      { id: 1, nickname: "김벤토" },
       { id: 12, nickname: "Manager2" },
     ],
   },
@@ -52,6 +52,19 @@ let mockCalendars = [
       { id: 11, nickname: "Manager1" },
       { id: 12, nickname: "Manager2" },
     ],
+  },
+];
+
+let mockSubscriptions = [
+  {
+    calendar_id: 1,
+    calendar_name: "dlwlrma",
+    calendar_description: "IU",
+  },
+  {
+    calendar_id: 2,
+    calendar_name: "bts_official",
+    calendar_description: "BTS",
   },
 ];
 
@@ -257,5 +270,23 @@ export const calendarHandlers = [
       ctx.status(200),
       ctx.json({ message: "캘린더가 성공적으로 삭제되었습니다." }),
     );
+  }),
+
+  rest.get("/api/users/:user_id/subscriptions", (req, res, ctx) => {
+    const token = req.headers.get("Authorization");
+
+    // 토큰 검증
+    if (!token || token !== "Bearer fake_token") {
+      return res(
+        ctx.status(401),
+        ctx.json({
+          error: "인증 실패",
+          message: "로그인이 필요합니다. 다시 로그인해 주세요.",
+        }),
+      );
+    }
+
+    // 구독한 캘린더 반환
+    return res(ctx.status(200), ctx.json(mockSubscriptions));
   }),
 ];

--- a/src/mocks/handlers/calendarHandlers.js
+++ b/src/mocks/handlers/calendarHandlers.js
@@ -60,35 +60,50 @@ let mockCalendars = [
 let mockSubscriptions = [
   {
     calendar_id: 1,
-    calendar_name: "dlwlrma",
-    calendar_description: "IU",
+    calendar_name: "IU",
+    calendar_description: "dlwlrma",
   },
   {
     calendar_id: 2,
-    calendar_name: "bts_official",
-    calendar_description: "BTS",
+    calendar_name: "BTS",
+    calendar_description: "bts_official",
   },
   {
     calendar_id: 3,
-    calendar_name: "Pooding_official",
-    calendar_description: "poodingdev",
+    calendar_name: "PoodingDev",
+    calendar_description: "eventoteam",
   },
   {
     calendar_id: 4,
-    calendar_name: "MC Yoo",
-    calendar_description: "유재석",
+    calendar_name: "유재석",
+    calendar_description: "MC Yoo",
   },
 ];
-let mockOpenCalendars = [
+
+let mockSearchCalendars = [
   {
     calendar_id: 1,
-    calendar_name: "dlwlrma",
-    calendar_description: "IU",
+    name: "IU",
+    description: "IU의 캘린더입니다.",
+    is_public: true,
+    color: "#FF5733",
+    creator: { nickname: "dlwlrma" },
   },
   {
     calendar_id: 2,
-    calendar_name: "bts_official",
-    calendar_description: "BTS",
+    name: "BTS",
+    description: "BTS의 캘린더입니다.",
+    is_public: true,
+    color: "#33FF57",
+    creator: { nickname: "bts_official" },
+  },
+  {
+    calendar_id: 3,
+    name: "Travel",
+    description: "여행 캘린더입니다.",
+    is_public: true,
+    color: "#3357FF",
+    creator: { nickname: "traveler" },
   },
 ];
 
@@ -110,63 +125,63 @@ export const calendarHandlers = [
     return res(ctx.status(200), ctx.json(mockCalendars));
   }),
 
-  // 관리자 초대 핸들러
-  rest.post("/api/calendars/:calendarId/admins", async (req, res, ctx) => {
-    const token = req.headers.get("Authorization");
-    const { calendarId } = req.params;
-    const { invitation_code } = await req.json();
-    const user_id = 2; // 이 부분은 실제로 요청을 보낸 사용자 ID로 변경 필요 (여기서는 예시로 user_id = 2 사용)
+  // // 관리자 초대 핸들러
+  // rest.post("/api/calendars/:calendarId/admins", async (req, res, ctx) => {
+  //   const token = req.headers.get("Authorization");
+  //   const { calendarId } = req.params;
+  //   const { invitation_code } = await req.json();
+  //   const user_id = 2; // 이 부분은 실제로 요청을 보낸 사용자 ID로 변경 필요 (여기서는 예시로 user_id = 2 사용)
 
-    if (!token || token !== "Bearer fake_token") {
-      return res(
-        ctx.status(401),
-        ctx.json({
-          error: "인증 실패",
-          message: "로그인이 필요한 서비스입니다. 다시 로그인해 주세요.",
-        }),
-      );
-    }
+  //   if (!token || token !== "Bearer fake_token") {
+  //     return res(
+  //       ctx.status(401),
+  //       ctx.json({
+  //         error: "인증 실패",
+  //         message: "로그인이 필요한 서비스입니다. 다시 로그인해 주세요.",
+  //       }),
+  //     );
+  //   }
 
-    // 캘린더 찾기
-    const calendarIndex = mockCalendars.findIndex(
-      (cal) => cal.calendar_id === parseInt(calendarId),
-    );
+  //   // 캘린더 찾기
+  //   const calendarIndex = mockCalendars.findIndex(
+  //     (cal) => cal.calendar_id === parseInt(calendarId),
+  //   );
 
-    if (calendarIndex === -1) {
-      return res(
-        ctx.status(404),
-        ctx.json({
-          error: "not_found",
-          message: "해당 캘린더를 찾을 수 없습니다.",
-        }),
-      );
-    }
+  //   if (calendarIndex === -1) {
+  //     return res(
+  //       ctx.status(404),
+  //       ctx.json({
+  //         error: "not_found",
+  //         message: "해당 캘린더를 찾을 수 없습니다.",
+  //       }),
+  //     );
+  //   }
 
-    // 초대 코드가 일치하는지 확인
-    if (mockCalendars[calendarIndex].invitation_code !== invitation_code) {
-      return res(
-        ctx.status(400),
-        ctx.json({
-          error: "유효하지 않은 초대 코드입니다.",
-        }),
-      );
-    }
+  //   // 초대 코드가 일치하는지 확인
+  //   if (mockCalendars[calendarIndex].invitation_code !== invitation_code) {
+  //     return res(
+  //       ctx.status(400),
+  //       ctx.json({
+  //         error: "유효하지 않은 초대 코드입니다.",
+  //       }),
+  //     );
+  //   }
 
-    // 관리자로 추가하기 (이미 관리자가 아닌 경우에만 추가)
-    if (!mockCalendars[calendarIndex].admins.includes(user_id)) {
-      mockCalendars[calendarIndex].admins.push(user_id);
-    }
+  //   // 관리자로 추가하기 (이미 관리자가 아닌 경우에만 추가)
+  //   if (!mockCalendars[calendarIndex].admins.includes(user_id)) {
+  //     mockCalendars[calendarIndex].admins.push(user_id);
+  //   }
 
-    // 201 Created 응답 반환
-    return res(
-      ctx.status(201),
-      ctx.json({
-        message: "사용자가 성공적으로 관리자로 초대되었습니다.",
-        user_id,
-        calendar_id: parseInt(calendarId),
-      }),
-    );
-  }),
+  //   // 201 Created 응답 반환
+  //   return res(
+  //     ctx.status(201),
+  //     ctx.json({
+  //       message: "사용자가 성공적으로 관리자로 초대되었습니다.",
+  //       user_id,
+  //       calendar_id: parseInt(calendarId),
+  //     }),
+  //   );
+  // }),
 
   // 캘린더 생성 핸들러
   rest.post("/api/calendars", async (req, res, ctx) => {
@@ -296,10 +311,10 @@ export const calendarHandlers = [
     );
   }),
 
+  //구독 조회
   rest.get("/api/users/:user_id/subscriptions", (req, res, ctx) => {
     const token = req.headers.get("Authorization");
 
-    // 토큰 검증
     if (!token || token !== "Bearer fake_token") {
       return res(
         ctx.status(401),
@@ -314,20 +329,7 @@ export const calendarHandlers = [
     return res(ctx.status(200), ctx.json(mockSubscriptions));
   }),
 
-  rest.get("/api/users/calendars/search", (req, res, ctx) => {
-    const token = req.headers.get("Authorization");
-    if (!token || token !== "Bearer fake_token") {
-      return res(
-        ctx.status(401),
-        ctx.json({
-          error: "인증 실패",
-          message: "로그인이 필요합니다. 다시 로그인해 주세요.",
-        }),
-      );
-    }
-    return res(ctx.status(200), ctx.json(mockOpenCalendars));
-  }),
-
+  // 구독 취소
   rest.delete("/api/subscriptions/:calendar_id", async (req, res, ctx) => {
     const token = req.headers.get("Authorization");
     const { calendar_id } = req.params;
@@ -358,9 +360,54 @@ export const calendarHandlers = [
       );
     }
 
-
     mockSubscriptions.splice(calendarIndex, 1);
 
-    return res(ctx.status(204)); 
+    return res(ctx.status(204));
+  }),
+
+  // 공개 캘린더 검색
+  rest.get("/api/users/calendars/search", (req, res, ctx) => {
+    const token = req.headers.get("Authorization");
+    const nickname = req.url.searchParams.get("nickname");
+
+    // 인증 확인
+    if (!token || token !== "Bearer fake_token") {
+      return res(
+        ctx.status(401),
+        ctx.json({
+          error: "인증 실패",
+          message: "로그인이 필요합니다. 다시 로그인해 주세요.",
+        }),
+      );
+    }
+
+    // 검색어 확인
+    if (!nickname) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          error: "잘못된 요청",
+          message: "닉네임 쿼리 파라미터가 필요합니다.",
+        }),
+      );
+    }
+
+    // 닉네임 필터링
+    const filteredCalendars = mockSearchCalendars.filter((calendar) =>
+      calendar.creator.nickname.toLowerCase().includes(nickname.toLowerCase()),
+    );
+
+    // 결과 반환
+    if (filteredCalendars.length > 0) {
+      return res(ctx.status(200), ctx.json(filteredCalendars));
+    } else {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          error: "사용자 없음",
+          message: "일치하는 닉네임의 사용자를 찾을 수 없습니다.",
+        }),
+      );
+    }
   }),
 ];

--- a/src/mocks/handlers/calendarHandlers.js
+++ b/src/mocks/handlers/calendarHandlers.js
@@ -68,6 +68,16 @@ let mockSubscriptions = [
     calendar_name: "bts_official",
     calendar_description: "BTS",
   },
+  {
+    calendar_id: 3,
+    calendar_name: "Pooding_official",
+    calendar_description: "poodingdev",
+  },
+  {
+    calendar_id: 4,
+    calendar_name: "MC Yoo",
+    calendar_description: "유재석",
+  },
 ];
 let mockOpenCalendars = [
   {
@@ -316,5 +326,43 @@ export const calendarHandlers = [
       );
     }
     return res(ctx.status(200), ctx.json(mockOpenCalendars));
+  }),
+
+  rest.delete("/api/unsubscribe", async (req, res, ctx) => {
+    const token = req.headers.get("Authorization");
+    const { calendar_id } = await req.json(); // 비동기로 요청 본문 읽기
+
+    if (!token || token !== "Bearer fake_token") {
+      return res(
+        ctx.status(401),
+        ctx.json({
+          error: "인증 실패",
+          message: "로그인이 필요합니다. 다시 로그인해 주세요.",
+        }),
+      );
+    }
+
+    const calendarIndex = mockSubscriptions.findIndex(
+      (calendar) => calendar.calendar_id === parseInt(calendar_id, 10),
+    );
+
+    if (calendarIndex === -1) {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          error: "캘린더 없음",
+          message: "구독 중인 캘린더를 찾을 수 없습니다.",
+        }),
+      );
+    }
+
+    mockSubscriptions.splice(calendarIndex, 1); // 삭제
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        message: "구독이 성공적으로 취소되었습니다.",
+      }),
+    );
   }),
 ];

--- a/src/mocks/handlers/calendarHandlers.js
+++ b/src/mocks/handlers/calendarHandlers.js
@@ -328,10 +328,11 @@ export const calendarHandlers = [
     return res(ctx.status(200), ctx.json(mockOpenCalendars));
   }),
 
-  rest.delete("/api/unsubscribe", async (req, res, ctx) => {
+  rest.delete("/api/subscriptions/:calendar_id", async (req, res, ctx) => {
     const token = req.headers.get("Authorization");
-    const { calendar_id } = await req.json(); // 비동기로 요청 본문 읽기
+    const { calendar_id } = req.params;
 
+    // 인증 토큰 확인
     if (!token || token !== "Bearer fake_token") {
       return res(
         ctx.status(401),
@@ -342,6 +343,7 @@ export const calendarHandlers = [
       );
     }
 
+    // 해당 캘린더 인덱스 확인
     const calendarIndex = mockSubscriptions.findIndex(
       (calendar) => calendar.calendar_id === parseInt(calendar_id, 10),
     );
@@ -356,13 +358,9 @@ export const calendarHandlers = [
       );
     }
 
-    mockSubscriptions.splice(calendarIndex, 1); // 삭제
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        message: "구독이 성공적으로 취소되었습니다.",
-      }),
-    );
+    mockSubscriptions.splice(calendarIndex, 1);
+
+    return res(ctx.status(204)); 
   }),
 ];

--- a/src/mocks/handlers/calendarHandlers.js
+++ b/src/mocks/handlers/calendarHandlers.js
@@ -1,5 +1,6 @@
 import { rest } from "msw";
 
+//내 캘린더
 let mockCalendars = [
   {
     calendar_id: 1,
@@ -55,7 +56,20 @@ let mockCalendars = [
   },
 ];
 
+//구독한 캘린더
 let mockSubscriptions = [
+  {
+    calendar_id: 1,
+    calendar_name: "dlwlrma",
+    calendar_description: "IU",
+  },
+  {
+    calendar_id: 2,
+    calendar_name: "bts_official",
+    calendar_description: "BTS",
+  },
+];
+let mockOpenCalendars = [
   {
     calendar_id: 1,
     calendar_name: "dlwlrma",
@@ -69,7 +83,7 @@ let mockSubscriptions = [
 ];
 
 export const calendarHandlers = [
-  // 캘린더 리스트 가져오기 핸들러
+  // 내 캘린더
   rest.get("/api/calendars/admins", (req, res, ctx) => {
     const token = req.headers.get("Authorization");
 
@@ -103,7 +117,7 @@ export const calendarHandlers = [
       );
     }
 
-    // 캘린더를 찾기
+    // 캘린더 찾기
     const calendarIndex = mockCalendars.findIndex(
       (cal) => cal.calendar_id === parseInt(calendarId),
     );
@@ -288,5 +302,19 @@ export const calendarHandlers = [
 
     // 구독한 캘린더 반환
     return res(ctx.status(200), ctx.json(mockSubscriptions));
+  }),
+
+  rest.get("/api/users/calendars/search", (req, res, ctx) => {
+    const token = req.headers.get("Authorization");
+    if (!token || token !== "Bearer fake_token") {
+      return res(
+        ctx.status(401),
+        ctx.json({
+          error: "인증 실패",
+          message: "로그인이 필요합니다. 다시 로그인해 주세요.",
+        }),
+      );
+    }
+    return res(ctx.status(200), ctx.json(mockOpenCalendars));
   }),
 ];

--- a/src/pages/LoginPostCode.jsx
+++ b/src/pages/LoginPostCode.jsx
@@ -34,8 +34,7 @@ export default function LoginPostCode() {
         // 전역 상태 업데이트
         setLoggedIn(true);
         setUserInfo(userInfo);
-        console.log(`-----User ${userInfo.user_id} 로그인-----`);
-        // 캘린더 화면으로 이동
+
         navigate("/calendar");
       } catch (error) {
         setErrorMessage("인증에 실패했습니다. 다시 시도해 주세요.");

--- a/src/pages/LoginPostCode.jsx
+++ b/src/pages/LoginPostCode.jsx
@@ -29,12 +29,12 @@ export default function LoginPostCode() {
 
         // 사용자 정보 가져오기
         const userInfo = await fetchUserInfo(token);
-        console.log("User Info:", userInfo);
+        // console.log("User Info:", userInfo);
 
         // 전역 상태 업데이트
         setLoggedIn(true);
         setUserInfo(userInfo);
-
+        console.log(`-----User ${userInfo.user_id} 로그인-----`);
         // 캘린더 화면으로 이동
         navigate("/calendar");
       } catch (error) {

--- a/src/pages/LoginPostCode.jsx
+++ b/src/pages/LoginPostCode.jsx
@@ -27,12 +27,14 @@ export default function LoginPostCode() {
         // 토큰 저장
         localStorage.setItem("token", token);
 
-        // 사용자 정보
+        // 사용자 정보 가져오기
         const userInfo = await fetchUserInfo(token);
-        console.log("User ID:", userInfo.user_id);
+        console.log("User Info:", userInfo);
+
         // 전역 상태 업데이트
         setLoggedIn(true);
         setUserInfo(userInfo);
+
         // 캘린더 화면으로 이동
         navigate("/calendar");
       } catch (error) {

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -56,9 +56,9 @@ export default function Profile() {
       <div className="h-[100vh] bg-eventoWhite pl-[18rem] pt-[4rem]">
         <div className="ml-[5rem] mt-[2rem] flex items-center text-center">
           <Link to="/">
-            <IoChevronBack className="text-[1.4rem]" />
+            <IoChevronBack className="text-[1.2rem]" />
           </Link>
-          <p className="text-[1.4rem]">&nbsp; 내 프로필</p>
+          <p className="text-[1.1rem]">&nbsp; 내 프로필</p>
         </div>
         <div className="flex h-full -translate-y-[6rem] items-center justify-center">
           <div className="flex h-[30rem] w-[30rem] flex-col items-center justify-center">
@@ -70,7 +70,7 @@ export default function Profile() {
               <li className="text-center text-[1.4rem] font-semibold text-darkGray">
                 {userInfo.userName}
               </li>
-              <li className="text-center text-[1.1rem] text-darkGray">
+              <li className="text-center text-[1.0rem] text-darkGray">
                 {userInfo.userEmail}
               </li>
               <li className="flex items-center justify-center gap-1 text-center">
@@ -86,7 +86,7 @@ export default function Profile() {
             onClick={editClick}
           />
         </div>
-        <div className="absolute bottom-[3rem] right-[4rem]">
+        <div className="absolute bottom-[5rem] right-[6rem]">
           <button
             onClick={toggleConfirm}
             className="w-[7rem] gap-3 rounded-[0.625rem] border-[0.15rem] border-lightGray bg-eventoWhite px-3 py-2 text-darkGray/80 hover:border-lightRed hover:bg-lightRed hover:text-darkRed active:border-darkRed active:bg-darkRed active:text-white"

--- a/src/pages/ProfileEdit.jsx
+++ b/src/pages/ProfileEdit.jsx
@@ -149,31 +149,27 @@ export default function ProfileEdit() {
                   value={userNickname}
                   onChange={handleNickName}
                   placeholder="닉네임 수정"
-                  className="w-[9rem] rounded-lg bg-gray-200 p-[2px] px-3 py-2 text-center focus:border-[1px] focus:border-none focus:bg-eventoPurpleLight/80 focus:outline-none"
+                  className="w-[9rem] rounded-lg bg-gray-200 p-[2px] px-3 py-2 text-center font-semibold text-darkGray focus:border-[1px] focus:border-none focus:bg-eventoPurpleLight/80 focus:outline-none"
                 />
               </div>
 
               <ul className="flex w-[20rem] flex-col space-y-[1.5rem] p-[2px]">
                 <li className="flex items-center justify-between">
-                  <span className="text-darkGray">이름</span>
-                  <span className="font-semibold text-darkGray">
-                    {userName}
-                  </span>
+                  <span className="font-semibold text-darkGray">이름</span>
+                  <span className="text-darkGray">{userName}</span>
                 </li>
                 <li className="flex items-center justify-between">
-                  <span className="text-darkGray">이메일</span>
-                  <span className="font-semibold text-darkGray">
-                    {userEmail}
-                  </span>
+                  <span className="font-semibold text-darkGray">이메일</span>
+                  <span className="text-darkGray">{userEmail}</span>
                 </li>
                 <li className="flex items-center justify-between">
-                  <span className="text-darkGray">내 생일</span>
+                  <span className="font-semibold text-darkGray">내 생일</span>
                   <div className="flex translate-x-[0.5rem] items-center">
                     <input
                       type="date"
                       value={userBirth}
                       onChange={handleBirthChange}
-                      className="rounded-lg bg-eventoWhite p-1 font-semibold text-darkGray"
+                      className="rounded-lg bg-eventoWhite p-1 text-darkGray"
                     />
                   </div>
                 </li>

--- a/src/pages/ProfileEdit.jsx
+++ b/src/pages/ProfileEdit.jsx
@@ -1,7 +1,8 @@
+import "react-datepicker/dist/react-datepicker.css";
+import DatePicker from "react-datepicker";
 import React, { useEffect, useState } from "react";
 import axios from "axios";
-import { FaToggleOff, FaToggleOn } from "react-icons/fa6";
-import { IoCalendarOutline, IoPersonCircleOutline } from "react-icons/io5";
+import { IoPersonCircleOutline } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
 
 export default function ProfileEdit() {
@@ -10,7 +11,7 @@ export default function ProfileEdit() {
   const [userName, setUserName] = useState("");
   const [userNickname, setUserNickname] = useState("");
   const [userEmail, setUserEmail] = useState("");
-  const [userBirth, setUserBirth] = useState("");
+  const [userBirth, setUserBirth] = useState(null); // DatePicker에서 사용하는 Date 객체
   const [isToggled, setIsToggled] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -18,7 +19,7 @@ export default function ProfileEdit() {
   useEffect(() => {
     async function fetchUserInfo() {
       try {
-        const token = localStorage.getItem("token"); // 토큰 가져오기
+        const token = localStorage.getItem("token");
         const response = await axios.get("/api/users/me", {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -34,17 +35,17 @@ export default function ProfileEdit() {
           is_birth_public,
         } = response.data;
 
-        // 상태 업데이트
         setUserId(user_id);
         setUserName(user_name);
         setUserNickname(user_nickname);
         setUserEmail(user_email);
         setIsToggled(is_birth_public);
-        // date input
+
+        // 날짜를 Date 객체로 변환
         if (user_birth) {
           const parsedDate = new Date(user_birth);
           if (!isNaN(parsedDate.getTime())) {
-            setUserBirth(parsedDate.toISOString().substring(0, 10));
+            setUserBirth(parsedDate);
           }
         }
       } catch (error) {
@@ -57,11 +58,6 @@ export default function ProfileEdit() {
 
     fetchUserInfo();
   }, []);
-
-  // 생일 수정 핸들러
-  const handleBirthChange = (e) => {
-    setUserBirth(e.target.value);
-  };
 
   // 닉네임 수정 핸들러
   const handleNickName = (e) => {
@@ -82,10 +78,12 @@ export default function ProfileEdit() {
       }
 
       const response = await axios.post(
-        `/api/users/${userId}`, // 사용자 정보 수정
+        `/api/users/${userId}`,
         {
           user_nickname: userNickname,
-          user_birth: userBirth || null,
+          user_birth: userBirth
+            ? userBirth.toISOString().substring(0, 10)
+            : null, // 날짜를 ISO 문자열로 변환
           is_birth_public: isToggled,
         },
         {
@@ -104,7 +102,6 @@ export default function ProfileEdit() {
       console.error("사용자 정보 수정 실패:", error);
 
       if (error.response) {
-        // 서버 응답이 있는 경우
         const { status, data } = error.response;
 
         if (status === 401) {
@@ -121,7 +118,6 @@ export default function ProfileEdit() {
           setErrorMessage("사용자 정보를 수정하지 못했습니다.");
         }
       } else {
-        // 서버 응답이 없는 경우
         setErrorMessage(
           "네트워크 오류가 발생했습니다. 인터넷 연결을 확인해 주세요.",
         );
@@ -134,70 +130,66 @@ export default function ProfileEdit() {
   };
 
   return (
-    <>
-      <div className="h-[100vh] bg-eventoWhite pl-[18rem] pt-[4rem]">
-        <div className="ml-[5rem] mt-[2rem] flex items-center text-center">
-          <p className="text-[1.4rem]">&nbsp; 내 프로필 수정</p>
-        </div>
-        <div className="flex h-full -translate-x-[2rem] -translate-y-[6rem] flex-col items-center justify-center">
-          <div className="h-[15rem] w-[40rem]">
-            <div className="flex items-center justify-center space-x-[6rem]">
-              <div className="flex flex-col items-center gap-3">
-                <IoPersonCircleOutline className="h-[7.5rem] w-[7.5rem] object-cover text-eventoPurpleBase" />
-                <input
-                  type="text"
-                  value={userNickname}
-                  onChange={handleNickName}
-                  placeholder="닉네임 수정"
-                  className="w-[9rem] rounded-lg bg-gray-200 p-[2px] px-3 py-2 text-center font-semibold text-darkGray focus:border-[1px] focus:border-none focus:bg-eventoPurpleLight/80 focus:outline-none"
+    <div className="h-[100vh] bg-eventoWhite pl-[18rem] pt-[4rem]">
+      <div className="ml-[5rem] mt-[2rem] flex items-center text-center">
+        <p className="text-[1.4rem]">&nbsp; 내 프로필 수정</p>
+      </div>
+      <div className="flex h-full -translate-x-[2rem] -translate-y-[6rem] flex-col items-center justify-center">
+        <div className="h-[15rem] w-[40rem]">
+          <div className="flex items-center justify-center space-x-[6rem]">
+            <div className="flex flex-col items-center gap-3">
+              <IoPersonCircleOutline className="h-[7.5rem] w-[7.5rem] object-cover text-eventoPurpleBase" />
+              <input
+                type="text"
+                value={userNickname}
+                onChange={handleNickName}
+                placeholder="닉네임 수정"
+                className="w-[9rem] rounded-lg bg-gray-200 p-[2px] px-3 py-2 text-center font-semibold text-darkGray focus:border-[1px] focus:border-none focus:bg-eventoPurpleLight/80 focus:outline-none"
+              />
+            </div>
+
+            <ul className="flex w-[20rem] flex-col space-y-[1.5rem] p-[2px]">
+              <li className="flex items-center justify-between">
+                <span className="font-semibold text-darkGray">이름</span>
+                <span className="text-darkGray">{userName}</span>
+              </li>
+              <li className="flex items-center justify-between">
+                <span className="font-semibold text-darkGray">이메일</span>
+                <span className="text-darkGray">{userEmail}</span>
+              </li>
+              <li className="flex items-center justify-between">
+                <span className="font-semibold text-darkGray">내 생일</span>
+                <DatePicker
+                  selected={userBirth}
+                  onChange={(date) => setUserBirth(date)} // Date 객체 업데이트
+                  dateFormat="yyyy-MM-dd"
+                  className="p-1 text-right rounded-lg bg-eventoWhite text-darkGray"
                 />
-              </div>
-
-              <ul className="flex w-[20rem] flex-col space-y-[1.5rem] p-[2px]">
-                <li className="flex items-center justify-between">
-                  <span className="font-semibold text-darkGray">이름</span>
-                  <span className="text-darkGray">{userName}</span>
-                </li>
-                <li className="flex items-center justify-between">
-                  <span className="font-semibold text-darkGray">이메일</span>
-                  <span className="text-darkGray">{userEmail}</span>
-                </li>
-                <li className="flex items-center justify-between">
-                  <span className="font-semibold text-darkGray">내 생일</span>
-                  <div className="flex translate-x-[0.5rem] items-center">
-                    <input
-                      type="date"
-                      value={userBirth}
-                      onChange={handleBirthChange}
-                      className="rounded-lg bg-eventoWhite p-1 text-darkGray"
-                    />
-                  </div>
-                </li>
-              </ul>
-            </div>
-
-            <div className="inset-3 mt-[3rem] flex justify-center space-x-[0.5rem]">
-              <button
-                onClick={handleCancel}
-                className="w-[5rem] rounded-[0.625rem] border-2 border-eventoPurpleBase bg-white px-3 py-2 text-eventoPurpleBase"
-              >
-                취소
-              </button>
-              <button
-                onClick={handleSave}
-                className="w-[5rem] rounded-[0.625rem] bg-eventoPurpleBase px-3 py-2 text-white"
-              >
-                저장
-              </button>
-            </div>
-            {errorMessage && (
-              <div className="mt-[2rem] text-center text-[1rem] text-darkRed">
-                {errorMessage}
-              </div>
-            )}
+              </li>
+            </ul>
           </div>
+
+          <div className="inset-3 mt-[3rem] flex justify-center space-x-[0.5rem]">
+            <button
+              onClick={handleCancel}
+              className="w-[5rem] rounded-[0.625rem] border-2 border-eventoPurpleBase bg-white px-3 py-2 text-eventoPurpleBase"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleSave}
+              className="w-[5rem] rounded-[0.625rem] bg-eventoPurpleBase px-3 py-2 text-white"
+            >
+              저장
+            </button>
+          </div>
+          {errorMessage && (
+            <div className="mt-[2rem] text-center text-[1rem] text-darkRed">
+              {errorMessage}
+            </div>
+          )}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/pages/Subscription.jsx
+++ b/src/pages/Subscription.jsx
@@ -16,7 +16,7 @@ export default function Subscription() {
   const toggleSubscription = (id) => {
     setSubscribedCalendars((prevCalendars) =>
       prevCalendars.map((calendar) =>
-        calendar.id === id
+        calendar.calendar_id === id
           ? { ...calendar, isSubscribed: !calendar.isSubscribed } // 구독 상태 반전
           : calendar,
       ),
@@ -55,10 +55,10 @@ export default function Subscription() {
         <p className="text-[1.4rem]">&nbsp; 공개 캘린더</p>
       </div>
       <div className="flex w-full">
-        {/* <CaleanderSearch
+        <CaleanderSearch
           // openCalendars={openCalendars}
           toggleSubscription={toggleSubscription}
-        /> */}
+        />
         <SubsciptionCaleander
           openCalendars={subscribedCalendars}
           toggleSubscription={toggleSubscription}
@@ -117,7 +117,7 @@ function CaleanderSearch({ openCalendars, toggleSubscription }) {
         <ul className="my-[2rem] flex w-auto flex-col">
           {filteredSearch.map((calendar) => (
             <li
-              key={calendar.id}
+              key={calendar.calendar_id}
               className="my-2 flex w-[20rem] items-center gap-[1rem]"
             >
               <IoPersonCircleOutline className="h-[3.5rem] w-[3.5rem] object-cover" />
@@ -131,7 +131,7 @@ function CaleanderSearch({ openCalendars, toggleSubscription }) {
                     ? "border-[#E13228] bg-white text-[#E13228]"
                     : "border-[#E13228] bg-[#E13228] text-white"
                 }`}
-                onClick={() => toggleSubscription(calendar.id)}
+                onClick={() => toggleSubscription(calendar.calendar_id)}
               >
                 {calendar.isSubscribed ? "구독취소" : "구독"}
               </button>
@@ -151,7 +151,10 @@ function SubsciptionCaleander({ openCalendars, toggleSubscription }) {
         <h1>구독한 캘린더</h1>
         <ul className="flex w-auto flex-col">
           {openCalendars.map((calendar) => (
-            <li key={calendar.id} className="my-2 flex items-center gap-[1rem]">
+            <li
+              key={calendar.calendar_id}
+              className="my-2 flex items-center gap-[1rem]"
+            >
               <IoPersonCircleOutline className="h-[3.5rem] w-[3.5rem] object-cover" />
               <div>
                 <h3 className="text-[#493282]">{calendar.calendar_name}</h3>
@@ -165,7 +168,7 @@ function SubsciptionCaleander({ openCalendars, toggleSubscription }) {
                     ? "border-[#E13228] bg-white text-[#E13228]"
                     : "border-[#E13228] bg-[#E13228] text-white"
                 }`}
-                onClick={() => toggleSubscription(calendar.id)}
+                onClick={() => toggleSubscription(calendar.calendar_id)}
               >
                 {calendar.isSubscribed ? "구독취소" : "구독"}
               </button>

--- a/src/pages/Subscription.jsx
+++ b/src/pages/Subscription.jsx
@@ -75,12 +75,12 @@ export default function Subscription() {
   }, [userInfo, subscribedCalendars]);
 
   return (
-    <div className="h-[100vh] flex-col pl-[18rem] pt-[5rem]">
+    <div className="h-[100vh] bg-eventoWhite pl-[18rem] pt-[4rem]">
       <div className="ml-[5rem] mt-[2rem] flex items-center text-center">
         <Link to="/">
-          <IoChevronBack className="text-[1.4rem]" />
+          <IoChevronBack className="text-[1.2rem]" />
         </Link>
-        <p className="text-[1.4rem]">&nbsp; 공개 캘린더</p>
+        <p className="text-[1.1rem]">&nbsp; 공개 캘린더</p>
       </div>
       <div className="flex w-full">
         <CaleanderSearch
@@ -180,9 +180,9 @@ function SubscriptionCalender({ openCalendars, toggleSubscription }) {
   return (
     <>
       <div className="relative after:absolute after:bottom-0 after:left-0 after:top-0 after:w-[2px] after:bg-gray-200 after:content-['']"></div>
-      <section className="flex w-1/3 flex-col items-center">
+      <section className="flex flex-col items-center w-1/3">
         <h1>구독한 캘린더</h1>
-        <ul className="flex w-auto flex-col">
+        <ul className="flex flex-col w-auto">
           {openCalendars.map((calendar) => (
             <li
               key={calendar.calendar_id}

--- a/src/pages/Subscription.jsx
+++ b/src/pages/Subscription.jsx
@@ -13,19 +13,17 @@ export default function Subscription() {
   const { loggedIn, userInfo } = useAuth();
   const [subscribedCalendars, setSubscribedCalendars] = useState([]);
 
-  // 구독 상태를 토글하는 함수
   const toggleSubscription = async (id) => {
     const calendar = subscribedCalendars.find(
       (calendar) => calendar.calendar_id === id,
     );
 
     if (calendar.isSubscribed) {
-      // 구독 취소 요청
+      // 구독 취소
       try {
         const token = localStorage.getItem("token");
-        await axios.delete(`/api/unsubscribe`, {
+        await axios.delete(`/api/subscriptions/${id}`, {
           headers: { Authorization: `Bearer ${token}` },
-          data: { calendar_id: id }, // DELETE 요청 본문에 데이터 포함
         });
 
         // 상태 업데이트
@@ -44,7 +42,6 @@ export default function Subscription() {
     }
   };
 
-  // 초기 데이터 로드
   useEffect(() => {
     async function fetchData() {
       try {
@@ -57,11 +54,11 @@ export default function Subscription() {
         );
 
         if (subscribedCalendarsResponse.status === 200) {
-          // 상태 초기화: isSubscribed: true 추가
+          // 상태 초기화
           const initializedCalendars = subscribedCalendarsResponse.data.map(
             (calendar) => ({
               ...calendar,
-              isSubscribed: true, // 기본 상태 설정
+              isSubscribed: true,
             }),
           );
 


### PR DESCRIPTION
- [ ] 로그인 시 유저 아이디 전역 관리 #107
- [ ] resetState 사용하여 상태 관리 #108
- [ ] 사이드바, 캘린더 정보 창 userID 업데이트 #107
- [x] 헤더에 전역 상태 적용 #107
- [ ] 헤더 드랍다운 수정
- [ ] 사이드바 전역 상태 적용 #107
- [ ] 내 캘린더, 구독 캘린더 fetch 함수 통합
- [ ] 구독 캘린더 조회 #99
- [ ] 구독 편집 페이지 구독 캘린더 조회 #99
- [ ] 구독 취소 (변경된 api) #99
- [ ] 캘린더 검색 #99
- [ ] 프로필, 구독 페이지 UI 수정
- [ ] DatePicker CSS 수정 #110